### PR TITLE
Add ZooScreen iOS sample app

### DIFF
--- a/ZooScreen/.gitignore
+++ b/ZooScreen/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ZooScreen/Info.plist
+++ b/ZooScreen/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.ZooScreen</string>
+    <key>CFBundleName</key>
+    <string>ZooScreen</string>
+    <key>CFBundleDisplayName</key>
+    <string>ZooScreen</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>UILaunchScreen</key>
+    <dict/>
+</dict>
+</plist>

--- a/ZooScreen/LiveActivities/MonkeyActivity.swift
+++ b/ZooScreen/LiveActivities/MonkeyActivity.swift
@@ -1,0 +1,21 @@
+import ActivityKit
+import SwiftUI
+
+struct MonkeyActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var action: String
+        var progress: Double
+    }
+}
+
+struct MonkeyLiveActivityView: View {
+    let context: ActivityViewContext<MonkeyActivityAttributes>
+
+    var body: some View {
+        VStack {
+            Text("🐵 \\(context.state.action)")
+            ProgressView(value: context.state.progress)
+        }
+        .padding()
+    }
+}

--- a/ZooScreen/Models/Animal.swift
+++ b/ZooScreen/Models/Animal.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftUI
+
+struct Animal: Identifiable {
+    enum Species: String, CaseIterable {
+        case monkey
+        case dog
+        case cat
+        case turtle
+        case bird
+
+        var icon: String {
+            switch self {
+            case .monkey: return "🐵"
+            case .dog: return "🐶"
+            case .cat: return "🐱"
+            case .turtle: return "🐢"
+            case .bird: return "🐦"
+            }
+        }
+    }
+
+    let id = UUID()
+    let species: Species
+    var mood: String
+    var energy: Int
+}
+
+extension Animal {
+    static func random(for species: Species) -> Animal {
+        Animal(species: species, mood: ["Happy", "Hungry", "Sleepy"].randomElement()!, energy: Int.random(in: 1...100))
+    }
+}

--- a/ZooScreen/Models/ZooManager.swift
+++ b/ZooScreen/Models/ZooManager.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+class ZooManager: ObservableObject {
+    @Published private(set) var animals: [Animal]
+    private var timer: Timer?
+
+    init() {
+        animals = Animal.Species.allCases.map { Animal.random(for: $0) }
+        startTimer()
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
+            self?.updateAnimals()
+        }
+    }
+
+    private func updateAnimals() {
+        for index in animals.indices {
+            animals[index].mood = ["Happy", "Playful", "Tired", "Hungry"].randomElement()!
+            animals[index].energy = max(0, min(100, animals[index].energy + Int.random(in: -10...10)))
+        }
+    }
+}

--- a/ZooScreen/Package.swift
+++ b/ZooScreen/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ZooScreen",
+    platforms: [.iOS(.v17)],
+    products: [
+        .executable(name: "ZooScreen", targets: ["ZooScreen"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "ZooScreen",
+            path: ".",
+            resources: [.process("Info.plist")]
+        )
+    ]
+)

--- a/ZooScreen/README.md
+++ b/ZooScreen/README.md
@@ -1,0 +1,11 @@
+# ZooScreen
+
+A SwiftUI demo app for iOS 17+ showing interactive animals on the home screen and via Live Activities.
+
+## Features
+- Home screen list of animals (monkey, dog, cat, turtle, bird)
+- Each animal displays mood and energy that update every few seconds
+- Live Activity for the monkey on the lock screen
+- Widget showing monkey status
+
+Open `Package.swift` in Xcode 15+ to build and run.

--- a/ZooScreen/ViewModels/MonkeyActivityController.swift
+++ b/ZooScreen/ViewModels/MonkeyActivityController.swift
@@ -1,0 +1,21 @@
+import ActivityKit
+import Foundation
+
+class MonkeyActivityController {
+    static let shared = MonkeyActivityController()
+    private init() {}
+
+    private var activity: Activity<MonkeyActivityAttributes>?
+
+    func start() {
+        let attributes = MonkeyActivityAttributes()
+        let state = MonkeyActivityAttributes.ContentState(action: "swinging", progress: 0.1)
+        activity = try? Activity.request(attributes: attributes, contentState: state, pushType: nil)
+    }
+
+    func update(action: String, progress: Double) async {
+        guard let activity else { return }
+        let state = MonkeyActivityAttributes.ContentState(action: action, progress: progress)
+        await activity.update(ActivityContent(state: state, staleDate: nil))
+    }
+}

--- a/ZooScreen/Views/AnimalView.swift
+++ b/ZooScreen/Views/AnimalView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct AnimalView: View {
+    var animal: Animal
+
+    var body: some View {
+        HStack {
+            Text(animal.species.icon)
+                .font(.largeTitle)
+            VStack(alignment: .leading) {
+                Text(animal.species.rawValue.capitalized)
+                    .font(.headline)
+                Text("Mood: \(animal.mood)")
+                Text("Energy: \(animal.energy)")
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    AnimalView(animal: .random(for: .monkey))
+}

--- a/ZooScreen/Views/HomeView.swift
+++ b/ZooScreen/Views/HomeView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct HomeView: View {
+    @StateObject private var zooManager = ZooManager()
+
+    var body: some View {
+        NavigationStack {
+            List(zooManager.animals) { animal in
+                AnimalView(animal: animal)
+            }
+            .navigationTitle("Zoo Screen")
+        }
+        .task {
+            MonkeyActivityController.shared.start()
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/ZooScreen/Widgets/MonkeyWidget.swift
+++ b/ZooScreen/Widgets/MonkeyWidget.swift
@@ -1,0 +1,54 @@
+import WidgetKit
+import SwiftUI
+
+struct MonkeyWidgetEntry: TimelineEntry {
+    let date: Date
+    let action: String
+}
+
+struct MonkeyWidgetProvider: TimelineProvider {
+    func placeholder(in context: Context) -> MonkeyWidgetEntry {
+        MonkeyWidgetEntry(date: Date(), action: "swinging")
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (MonkeyWidgetEntry) -> ()) {
+        completion(MonkeyWidgetEntry(date: Date(), action: "swinging"))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<MonkeyWidgetEntry>) -> ()) {
+        let entry = MonkeyWidgetEntry(date: Date(), action: ["swinging", "napping", "eating"].randomElement()!)
+        let timeline = Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(10)))
+        completion(timeline)
+    }
+}
+
+struct MonkeyWidgetEntryView: View {
+    var entry: MonkeyWidgetProvider.Entry
+
+    var body: some View {
+        VStack {
+            Text("🐵")
+            Text(entry.action)
+        }
+    }
+}
+
+struct MonkeyWidget: Widget {
+    let kind: String = "MonkeyWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: MonkeyWidgetProvider()) { entry in
+            MonkeyWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Monkey Activity")
+        .description("Shows the monkey's current action.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+@main
+struct MonkeyWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        MonkeyWidget()
+    }
+}

--- a/ZooScreen/ZooScreenApp.swift
+++ b/ZooScreen/ZooScreenApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ZooScreenApp: App {
+    var body: some Scene {
+        WindowGroup {
+            HomeView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create iOS 17 SwiftUI sample `ZooScreen`
- add models, views, live activity and widget
- provide Swift Package setup and README

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_687ff58cbd58832e9d5b46528032e3b8